### PR TITLE
build: remove dependency on once_cell

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -62,11 +62,10 @@ dependencies = [
 
 [[package]]
 name = "cea608-types"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "env_logger",
  "log",
- "once_cell",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.71.1"
 [dependencies]
 log = "0.4"
 thiserror = "2"
-once_cell = "1"
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/examples/608-dump.rs
+++ b/examples/608-dump.rs
@@ -8,17 +8,17 @@ use cea608_types::*;
 
 use std::{env, io::Read};
 
-use once_cell::sync::Lazy;
+use std::sync::OnceLock;
+
+static TRACING: OnceLock<()> = OnceLock::new();
 
 #[macro_use]
 extern crate log;
 
 pub fn debug_init() {
-    static TRACING: Lazy<()> = Lazy::new(|| {
+    TRACING.get_or_init(|| {
         env_logger::init();
     });
-
-    Lazy::force(&TRACING);
 }
 
 fn main() -> std::process::ExitCode {

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,9 +10,8 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-once_cell = "1"
 log = "0.4"
-env_logger = "0.10"
+env_logger = "0.11"
 
 [dependencies.cea608-types]
 path = ".."

--- a/fuzz/fuzz_targets/code_from_bytes.rs
+++ b/fuzz/fuzz_targets/code_from_bytes.rs
@@ -3,17 +3,16 @@ use libfuzzer_sys::fuzz_target;
 
 use cea608_types::tables::Code;
 
-use once_cell::sync::Lazy;
+use std::sync::OnceLock;
 
-#[macro_use]
-extern crate log;
+static TRACING: OnceLock<()> = OnceLock::new();
+
+use log::info;
 
 pub fn debug_init() {
-    static TRACING: Lazy<()> = Lazy::new(|| {
+    TRACING.get_or_init(|| {
         env_logger::init();
     });
-
-    Lazy::force(&TRACING);
 }
 
 fuzz_target!(|data: [u8; 2]| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,13 +557,13 @@ mod test {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use once_cell::sync::Lazy;
+    use std::sync::OnceLock;
 
-    static TRACING: Lazy<()> = Lazy::new(|| {
-        env_logger::init();
-    });
+    static TRACING: OnceLock<()> = OnceLock::new();
 
     pub fn test_init_log() {
-        Lazy::force(&TRACING);
+        TRACING.get_or_init(|| {
+            env_logger::init();
+        });
     }
 }


### PR DESCRIPTION
We can use the std implementation of OnceLock instead.